### PR TITLE
Add install script for Unix/Linux

### DIFF
--- a/INSTALLERS.md
+++ b/INSTALLERS.md
@@ -1,0 +1,221 @@
+# LocalWeb Server Installers Guide
+
+This guide provides detailed information about the automated installation scripts for LocalWeb Server.
+
+## Overview
+
+LocalWeb Server provides automated installation scripts for:
+- **Windows 11 (64-bit)**: `install-windows.bat`
+- **Unix/Linux/macOS**: `install.sh`
+
+Both installers provide a guided, interactive installation process that handles all setup requirements.
+
+## Windows Installer (`install-windows.bat`)
+
+### Requirements
+- Windows 11 64-bit
+- Administrator privileges
+
+### What it does
+1. **Checks prerequisites**: Verifies Windows version and administrator privileges
+2. **Node.js installation**: Checks for Node.js and offers to install it if missing
+3. **File installation**: Copies application files to your chosen directory (default: `C:\Program Files\LocalWeb`)
+4. **Configuration**: Prompts for share directory, username, and password
+5. **Shortcuts**: Creates desktop and Start Menu shortcuts
+6. **Windows Service** (optional): Installs as a Windows service for automatic startup
+7. **Firewall rules**: Adds rules for ports 8080 (HTTP) and 8443 (HTTPS)
+
+### Usage
+```batch
+# Right-click on install-windows.bat and select "Run as administrator"
+```
+
+## Unix/Linux/macOS Installer (`install.sh`)
+
+### Requirements
+- Unix-like operating system (Linux distributions or macOS)
+- bash shell
+- sudo access (for some operations)
+
+### Supported Systems
+- **Ubuntu/Debian** and derivatives
+- **Fedora/RHEL/CentOS** and derivatives
+- **Arch Linux/Manjaro**
+- **macOS** (requires Homebrew for Node.js installation)
+- Other Unix-like systems (with manual Node.js installation)
+
+### What it does
+1. **OS detection**: Automatically detects your operating system
+2. **Node.js installation**: Checks for Node.js and offers OS-specific installation
+3. **File installation**: Copies files to your chosen directory (default: `~/.local/share/localweb`)
+4. **Configuration**: Prompts for share directory, username, and password
+5. **SSL certificates**: Generates self-signed certificates for HTTPS
+6. **Shortcuts**: 
+   - Creates command-line shortcut (`localweb` command)
+   - Creates desktop entry (Linux only)
+   - Adds to PATH if needed
+7. **System service** (optional):
+   - Linux: Creates systemd service
+   - macOS: Creates launchd service
+8. **Firewall configuration**: Configures firewall based on your system (ufw, firewalld)
+
+### Usage
+```bash
+# Make the script executable
+chmod +x install.sh
+
+# Run the installer
+./install.sh
+```
+
+## Installation Options
+
+### Installation Directory
+- **Windows default**: `C:\Program Files\LocalWeb`
+- **Unix/Linux/macOS default**: `~/.local/share/localweb`
+- You can specify a custom directory during installation
+
+### Share Directory
+The directory that will be served by LocalWeb:
+- **Windows default**: `C:\Users\%USERNAME%\Documents\Share`
+- **Unix/Linux/macOS default**: `~/LocalWebShare`
+- Creates an `Uploads` subdirectory automatically
+
+### Authentication
+- **Default username**: admin
+- **Default password**: localweb123 (if no password is provided)
+- Strong passwords are recommended for security
+
+### System Service
+Installing as a system service allows LocalWeb to:
+- Start automatically on system boot
+- Run in the background
+- Restart automatically if it crashes
+
+## Post-Installation
+
+### Starting the Server
+
+#### Windows
+1. Use the desktop shortcut "LocalWeb Server"
+2. From Start Menu → LocalWeb → LocalWeb Server
+3. If installed as service, it's already running
+
+#### Unix/Linux/macOS
+1. Run `localweb` from terminal
+2. Run `~/.local/share/localweb/start-localweb.sh`
+3. If installed as service, it's already running
+
+### Accessing the Server
+- HTTP: `http://localhost:8080`
+- HTTPS: `https://localhost:8443`
+
+Use the username and password you configured during installation.
+
+### Service Management
+
+#### Windows Service
+```batch
+# Stop the service
+net stop "LocalWeb Server"
+
+# Start the service
+net start "LocalWeb Server"
+
+# Disable automatic startup
+sc config "LocalWeb Server" start=manual
+```
+
+#### Linux (systemd)
+```bash
+# Check status
+sudo systemctl status localweb
+
+# Stop the service
+sudo systemctl stop localweb
+
+# Start the service
+sudo systemctl start localweb
+
+# Disable automatic startup
+sudo systemctl disable localweb
+```
+
+#### macOS (launchd)
+```bash
+# Stop the service
+launchctl unload ~/Library/LaunchAgents/com.localweb.server.plist
+
+# Start the service
+launchctl load ~/Library/LaunchAgents/com.localweb.server.plist
+```
+
+## Troubleshooting
+
+### Permission Issues
+- **Windows**: Ensure you run the installer as Administrator
+- **Unix/Linux**: The installer will request sudo access when needed
+
+### Node.js Installation Failed
+- Install Node.js manually from https://nodejs.org
+- Ensure you have internet connectivity
+- Check if your package manager is working correctly
+
+### Firewall Issues
+- Manually allow ports 8080 and 8443 in your firewall
+- Windows: Check Windows Defender Firewall settings
+- Linux: Check ufw/firewalld status
+- macOS: Check System Preferences → Security & Privacy → Firewall
+
+### SSL Certificate Issues
+- The installer creates self-signed certificates
+- Browsers will show security warnings - this is normal
+- Accept the certificate exception in your browser
+
+### Service Won't Start
+- Check logs:
+  - Windows: Event Viewer → Windows Logs → Application
+  - Linux: `journalctl -u localweb -f`
+  - macOS: `Console.app` → system.log
+- Ensure the configuration file is valid
+- Check if ports 8080/8443 are already in use
+
+## Uninstallation
+
+### Windows
+1. Stop the service if running
+2. Remove the service: Run as administrator in the installation directory:
+   ```batch
+   node uninstall-service.js
+   ```
+3. Delete the installation directory
+4. Remove shortcuts from Desktop and Start Menu
+
+### Unix/Linux/macOS
+1. Stop the service if running
+2. Remove the service:
+   - Linux: `sudo systemctl disable localweb && sudo rm /etc/systemd/system/localweb.service`
+   - macOS: `launchctl unload ~/Library/LaunchAgents/com.localweb.server.plist && rm ~/Library/LaunchAgents/com.localweb.server.plist`
+3. Delete the installation directory
+4. Remove the command from PATH
+5. Linux only: Remove desktop entry from `~/.local/share/applications/`
+
+## Security Considerations
+
+1. **Authentication**: Always use strong passwords
+2. **SSL/TLS**: The self-signed certificates provide encryption but not identity verification
+3. **Firewall**: Only open ports to trusted networks
+4. **File Access**: Be careful about which directories you share
+5. **Updates**: Keep Node.js and dependencies updated
+
+## Getting Help
+
+If you encounter issues:
+1. Check this guide's troubleshooting section
+2. Review the main README.md
+3. Check existing issues on GitHub
+4. Create a new issue with:
+   - Your operating system and version
+   - Installation method used
+   - Error messages
+   - Steps to reproduce the problem

--- a/README.md
+++ b/README.md
@@ -5,6 +5,37 @@ Serves directory over HTTP & HTTPS on Ubuntu Server LTS
 
 ## Installation
 
+### Method 1: Using Installers (Recommended)
+
+We provide automated installation scripts for easy setup:
+
+#### Windows 11 (64-bit)
+```bash
+# Right-click and "Run as Administrator"
+install-windows.bat
+```
+
+#### Unix/Linux/macOS
+```bash
+# Make the installer executable
+chmod +x install.sh
+
+# Run the installer
+./install.sh
+```
+
+The installers will:
+- Check and install Node.js if needed
+- Set up the application with dependencies
+- Configure authentication credentials
+- Generate SSL certificates
+- Create shortcuts and optionally install as a system service
+- Configure firewall rules
+
+> **Note:** For detailed installer documentation, troubleshooting, and uninstallation instructions, see [INSTALLERS.md](INSTALLERS.md)
+
+### Method 2: Manual Installation
+
 1. Install dependencies:
 ```bash
 sudo apt-get update

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,559 @@
+#!/bin/bash
+
+# LocalWeb Server Installation Script
+# Compatible with Unix/Linux/macOS
+
+set -e  # Exit on error
+
+# ANSI color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_info() {
+    echo -e "${BLUE}$1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}ERROR: $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}WARNING: $1${NC}"
+}
+
+# Detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        OS="macos"
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if [ -f /etc/os-release ]; then
+            . /etc/os-release
+            OS=$ID
+        else
+            OS="linux"
+        fi
+    else
+        OS="unknown"
+    fi
+}
+
+# Check if running as root (not recommended)
+check_root() {
+    if [ "$EUID" -eq 0 ]; then 
+        print_warning "Running as root is not recommended for security reasons."
+        read -p "Continue anyway? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    fi
+}
+
+# Welcome message
+show_welcome() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  LocalWeb Server Installation Wizard"
+    echo "  Unix/Linux/macOS Edition"
+    echo "==============================================="
+    echo
+    echo "Welcome to the LocalWeb Server installation wizard."
+    echo "This wizard will guide you through the installation process."
+    echo
+    read -p "Press Enter to continue..."
+}
+
+# Check Node.js installation
+check_nodejs() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Step 1: Checking Node.js Installation"
+    echo "==============================================="
+    echo
+
+    if command -v node &> /dev/null; then
+        NODE_VERSION=$(node --version)
+        print_success "Node.js $NODE_VERSION is already installed."
+        return 0
+    else
+        print_error "Node.js is not installed."
+        echo
+        read -p "Would you like to install Node.js? (Y/n) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+            install_nodejs
+        else
+            print_error "Node.js is required to run LocalWeb Server."
+            echo "Please install Node.js manually and run this installer again."
+            exit 1
+        fi
+    fi
+}
+
+# Install Node.js based on OS
+install_nodejs() {
+    print_info "Installing Node.js..."
+    
+    case $OS in
+        "ubuntu"|"debian")
+            # Install Node.js 20.x
+            curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+            ;;
+        "fedora"|"rhel"|"centos")
+            curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
+            sudo yum install -y nodejs
+            ;;
+        "arch"|"manjaro")
+            sudo pacman -S --noconfirm nodejs npm
+            ;;
+        "macos")
+            if command -v brew &> /dev/null; then
+                brew install node
+            else
+                print_error "Homebrew is not installed. Please install Homebrew first:"
+                echo "Visit: https://brew.sh"
+                exit 1
+            fi
+            ;;
+        *)
+            print_error "Automatic Node.js installation not supported for your OS."
+            echo "Please install Node.js manually from: https://nodejs.org"
+            exit 1
+            ;;
+    esac
+    
+    print_success "Node.js installed successfully!"
+}
+
+# Choose installation directory
+choose_install_dir() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Step 2: Choose Installation Directory"
+    echo "==============================================="
+    echo
+    
+    DEFAULT_DIR="$HOME/.local/share/localweb"
+    echo "Where would you like to install LocalWeb Server?"
+    echo
+    echo "Default: $DEFAULT_DIR"
+    echo
+    read -p "Press Enter to use default or type a custom path: " INSTALL_DIR
+    
+    if [ -z "$INSTALL_DIR" ]; then
+        INSTALL_DIR="$DEFAULT_DIR"
+    fi
+    
+    # Expand ~ to home directory
+    INSTALL_DIR="${INSTALL_DIR/#\~/$HOME}"
+    
+    echo
+    print_info "Installation directory: $INSTALL_DIR"
+    echo
+    
+    if [ -d "$INSTALL_DIR" ]; then
+        print_warning "Directory already exists. Existing files will be overwritten."
+        read -p "Continue? (Y/n) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]] && [[ ! -z $REPLY ]]; then
+            echo "Installation cancelled."
+            exit 0
+        fi
+    fi
+    
+    mkdir -p "$INSTALL_DIR"
+}
+
+# Copy application files
+install_files() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Step 3: Installing Application Files"
+    echo "==============================================="
+    echo
+    
+    print_info "Copying application files..."
+    
+    # Get the directory where the installer is located
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    
+    # Copy files, excluding certain directories and files
+    if command -v rsync &> /dev/null; then
+        rsync -av --exclude='.git' --exclude='node_modules' --exclude='config.js' \
+                  --exclude='ssl' --exclude='install.sh' --exclude='install-windows.bat' \
+                  "$SCRIPT_DIR/" "$INSTALL_DIR/"
+    else
+        # Fallback to cp if rsync is not available
+        cp -R "$SCRIPT_DIR"/* "$INSTALL_DIR/" 2>/dev/null
+        # Clean up files that should be excluded
+        rm -rf "$INSTALL_DIR/.git" "$INSTALL_DIR/node_modules" "$INSTALL_DIR/config.js" \
+               "$INSTALL_DIR/ssl" "$INSTALL_DIR/install.sh" "$INSTALL_DIR/install-windows.bat" 2>/dev/null
+    fi
+    
+    print_success "Application files copied"
+    
+    cd "$INSTALL_DIR"
+    
+    print_info "Installing dependencies..."
+    npm install --production
+    print_success "Dependencies installed"
+}
+
+# Configure the application
+configure_app() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Step 4: Configuration"
+    echo "==============================================="
+    echo
+    
+    print_info "Let's configure your LocalWeb Server."
+    echo
+    
+    # Share directory
+    DEFAULT_SHARE="$HOME/LocalWebShare"
+    echo "Enter the directory path you want to share:"
+    echo "(Default: $DEFAULT_SHARE)"
+    read -p "> " SHARE_DIR
+    
+    if [ -z "$SHARE_DIR" ]; then
+        SHARE_DIR="$DEFAULT_SHARE"
+    fi
+    
+    # Expand ~ to home directory
+    SHARE_DIR="${SHARE_DIR/#\~/$HOME}"
+    
+    # Create share directory if it doesn't exist
+    if [ ! -d "$SHARE_DIR" ]; then
+        mkdir -p "$SHARE_DIR"
+        mkdir -p "$SHARE_DIR/Uploads"
+        print_success "Created share directory: $SHARE_DIR"
+    fi
+    
+    # Username
+    echo
+    echo "Enter username for authentication:"
+    echo "(Default: admin)"
+    read -p "> " AUTH_USER
+    
+    if [ -z "$AUTH_USER" ]; then
+        AUTH_USER="admin"
+    fi
+    
+    # Password
+    echo
+    echo "Enter password for authentication:"
+    read -s -p "> " AUTH_PASS
+    echo
+    
+    if [ -z "$AUTH_PASS" ]; then
+        AUTH_PASS="localweb123"
+        print_warning "Using default password: localweb123"
+    fi
+    
+    # Create config.js
+    print_info "Creating configuration file..."
+    cat > "$INSTALL_DIR/config.js" << EOF
+module.exports = {
+  dir: '$SHARE_DIR',
+  user: '$AUTH_USER',
+  password: '$AUTH_PASS'
+};
+EOF
+    
+    print_success "Configuration saved"
+}
+
+# Create SSL certificates
+create_ssl_certs() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Step 5: SSL Certificate Setup"
+    echo "==============================================="
+    echo
+    
+    mkdir -p "$INSTALL_DIR/ssl"
+    
+    if [ -f "$INSTALL_DIR/ssl/localweb.key" ] && [ -f "$INSTALL_DIR/ssl/localweb.crt" ]; then
+        print_info "SSL certificates already exist."
+        read -p "Generate new certificates? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            return 0
+        fi
+    fi
+    
+    print_info "Generating self-signed SSL certificates..."
+    
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+        -keyout "$INSTALL_DIR/ssl/localweb.key" \
+        -out "$INSTALL_DIR/ssl/localweb.crt" \
+        -subj "/C=US/ST=State/L=City/O=LocalWeb/CN=localhost" \
+        2>/dev/null
+    
+    chmod 600 "$INSTALL_DIR/ssl/localweb.key"
+    print_success "SSL certificates generated"
+}
+
+# Create start scripts and shortcuts
+create_shortcuts() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Step 6: Creating Start Scripts"
+    echo "==============================================="
+    echo
+    
+    # Create start script
+    print_info "Creating start script..."
+    cat > "$INSTALL_DIR/start-localweb.sh" << EOF
+#!/bin/bash
+cd "$INSTALL_DIR"
+node server.js
+EOF
+    chmod +x "$INSTALL_DIR/start-localweb.sh"
+    
+    # Create command-line shortcut
+    LOCAL_BIN="$HOME/.local/bin"
+    mkdir -p "$LOCAL_BIN"
+    ln -sf "$INSTALL_DIR/start-localweb.sh" "$LOCAL_BIN/localweb"
+    
+    print_success "Start script created"
+    
+    # Add to PATH if not already there
+    if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+        print_info "Adding $LOCAL_BIN to PATH..."
+        
+        # Detect shell and update appropriate config file
+        if [ -n "$ZSH_VERSION" ]; then
+            echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> "$HOME/.zshrc"
+        elif [ -n "$BASH_VERSION" ]; then
+            echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> "$HOME/.bashrc"
+        fi
+        
+        print_warning "Please restart your terminal or run: export PATH=\"\$PATH:$LOCAL_BIN\""
+    fi
+    
+    # Create desktop entry for Linux desktop environments
+    if [[ "$OS" != "macos" ]] && [ -d "$HOME/.local/share/applications" ]; then
+        print_info "Creating desktop shortcut..."
+        cat > "$HOME/.local/share/applications/localweb.desktop" << EOF
+[Desktop Entry]
+Name=LocalWeb Server
+Comment=Local file sharing server
+Exec=$INSTALL_DIR/start-localweb.sh
+Icon=folder-remote
+Terminal=true
+Type=Application
+Categories=Network;FileTransfer;
+EOF
+        chmod +x "$HOME/.local/share/applications/localweb.desktop"
+        print_success "Desktop shortcut created"
+    fi
+}
+
+# Setup as system service (optional)
+setup_service() {
+    echo
+    read -p "Would you like to install LocalWeb as a system service? (y/N) " -n 1 -r
+    echo
+    
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        return 0
+    fi
+    
+    if [[ "$OS" == "macos" ]]; then
+        setup_launchd_service
+    else
+        setup_systemd_service
+    fi
+}
+
+# Setup systemd service for Linux
+setup_systemd_service() {
+    print_info "Creating systemd service..."
+    
+    SERVICE_FILE="/tmp/localweb.service"
+    cat > "$SERVICE_FILE" << EOF
+[Unit]
+Description=LocalWeb Server
+After=network.target
+
+[Service]
+Type=simple
+User=$USER
+WorkingDirectory=$INSTALL_DIR
+ExecStart=$(which node) $INSTALL_DIR/server.js
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    
+    sudo mv "$SERVICE_FILE" /etc/systemd/system/localweb.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable localweb.service
+    sudo systemctl start localweb.service
+    
+    print_success "Systemd service installed and started"
+}
+
+# Setup launchd service for macOS
+setup_launchd_service() {
+    print_info "Creating launchd service..."
+    
+    PLIST_FILE="$HOME/Library/LaunchAgents/com.localweb.server.plist"
+    cat > "$PLIST_FILE" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.localweb.server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$(which node)</string>
+        <string>$INSTALL_DIR/server.js</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$INSTALL_DIR</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>
+EOF
+    
+    launchctl load "$PLIST_FILE"
+    print_success "Launchd service installed and started"
+}
+
+# Configure firewall
+configure_firewall() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Step 7: Firewall Configuration"
+    echo "==============================================="
+    echo
+    
+    case $OS in
+        "ubuntu"|"debian")
+            if command -v ufw &> /dev/null; then
+                print_info "Configuring UFW firewall..."
+                sudo ufw allow 8080/tcp comment "LocalWeb HTTP"
+                sudo ufw allow 8443/tcp comment "LocalWeb HTTPS"
+                print_success "Firewall rules added"
+            else
+                print_info "UFW not found. Please configure your firewall manually."
+            fi
+            ;;
+        "fedora"|"rhel"|"centos")
+            if command -v firewall-cmd &> /dev/null; then
+                print_info "Configuring firewalld..."
+                sudo firewall-cmd --permanent --add-port=8080/tcp
+                sudo firewall-cmd --permanent --add-port=8443/tcp
+                sudo firewall-cmd --reload
+                print_success "Firewall rules added"
+            else
+                print_info "firewalld not found. Please configure your firewall manually."
+            fi
+            ;;
+        "macos")
+            print_info "macOS firewall configuration may require manual setup."
+            print_info "You may need to allow incoming connections when prompted."
+            ;;
+        *)
+            print_info "Please configure your firewall manually to allow ports 8080 and 8443."
+            ;;
+    esac
+}
+
+# Installation complete
+show_completion() {
+    clear
+    echo
+    echo "==============================================="
+    echo "  Installation Complete!"
+    echo "==============================================="
+    echo
+    print_success "LocalWeb Server has been successfully installed."
+    echo
+    echo "Installation Details:"
+    echo "---------------------"
+    echo "Location: $INSTALL_DIR"
+    echo "Share Directory: $SHARE_DIR"
+    echo "Username: $AUTH_USER"
+    echo "Password: ********"
+    echo
+    echo "Access URLs:"
+    echo "---------------------"
+    echo "HTTP:  http://localhost:8080"
+    echo "HTTPS: https://localhost:8443"
+    echo
+    echo "You can start the server by:"
+    echo "1. Running: localweb"
+    echo "2. Running: $INSTALL_DIR/start-localweb.sh"
+    
+    if systemctl is-active --quiet localweb.service 2>/dev/null; then
+        echo "3. The service is already running in the background"
+    elif launchctl list | grep -q com.localweb.server 2>/dev/null; then
+        echo "3. The service is already running in the background"
+    fi
+    
+    echo
+    read -p "Would you like to start the server now? (Y/n) " -n 1 -r
+    echo
+    
+    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+        print_info "Starting LocalWeb Server..."
+        cd "$INSTALL_DIR"
+        node server.js &
+        sleep 2
+        
+        # Try to open browser
+        if command -v xdg-open &> /dev/null; then
+            xdg-open "http://localhost:8080"
+        elif command -v open &> /dev/null; then
+            open "http://localhost:8080"
+        else
+            print_info "Please open http://localhost:8080 in your browser"
+        fi
+    fi
+}
+
+# Main installation flow
+main() {
+    detect_os
+    check_root
+    show_welcome
+    check_nodejs
+    choose_install_dir
+    install_files
+    configure_app
+    create_ssl_certs
+    create_shortcuts
+    setup_service
+    configure_firewall
+    show_completion
+}
+
+# Run main function
+main


### PR DESCRIPTION
Add a cross-platform Unix/Linux/macOS installer (`install.sh`) and update documentation to provide an automated and user-friendly installation experience.