### PR TITLE
Add SSL cert setup wizard to scripts

### DIFF
--- a/install-windows.bat
+++ b/install-windows.bat
@@ -306,11 +306,250 @@ echo svc.install(^);
     echo ✓ Windows service installed
 )
 
-:: Step 6: Firewall rules
+:: Step 6: SSL Certificate Setup
 cls
 echo.
 echo ===============================================
-echo  Step 6: Firewall Configuration
+echo  Step 6: SSL Certificate Setup Wizard
+echo ===============================================
+echo.
+
+if not exist "!INSTALL_DIR!\ssl" mkdir "!INSTALL_DIR!\ssl"
+
+if exist "!INSTALL_DIR!\ssl\localweb.key" if exist "!INSTALL_DIR!\ssl\localweb.crt" (
+    echo SSL certificates already exist.
+    echo.
+    echo Generate new certificates? (Y/N)
+    set /p REGEN_SSL="> "
+    if /i "!REGEN_SSL!" neq "Y" goto skip_ssl
+)
+
+echo This wizard will help you create a self-signed SSL certificate
+echo for secure HTTPS connections to your LocalWeb Server.
+echo.
+echo Choose certificate generation method:
+echo 1) Windows Certificate Utility (certutil)
+echo 2) Python (if installed)
+echo 3) Skip SSL setup
+echo.
+set /p SSL_METHOD="Enter your choice (1-3): "
+
+if "!SSL_METHOD!"=="1" goto ssl_certutil
+if "!SSL_METHOD!"=="2" goto ssl_python
+if "!SSL_METHOD!"=="3" goto skip_ssl
+
+:: Default to certutil
+echo Invalid choice. Using Windows Certificate Utility...
+goto ssl_certutil
+
+:ssl_certutil
+echo.
+echo Configuring SSL certificate details...
+echo.
+echo Enter certificate details (press Enter for defaults):
+echo.
+set /p SSL_CN="Common Name (hostname) [localhost]: "
+if "!SSL_CN!"=="" set SSL_CN=localhost
+
+set /p SSL_DAYS="Certificate validity (days) [365]: "
+if "!SSL_DAYS!"=="" set SSL_DAYS=365
+
+echo.
+echo Generating self-signed SSL certificates...
+
+:: Create certificate request config file
+(
+echo [Version]
+echo Signature="$Windows NT$"
+echo.
+echo [NewRequest]
+echo Subject="CN=!SSL_CN!, O=LocalWeb, L=City, S=State, C=US"
+echo KeyLength=2048
+echo KeyAlgorithm=RSA
+echo MachineKeySet=False
+echo RequestType=Cert
+echo KeyUsage=0xA0
+echo.
+echo [Extensions]
+echo 2.5.29.17 = "{text}dns=!SSL_CN!&dns=localhost&ipaddress=127.0.0.1"
+) > "!INSTALL_DIR!\ssl\cert_config.inf"
+
+:: Generate certificate
+certreq -new -f "!INSTALL_DIR!\ssl\cert_config.inf" "!INSTALL_DIR!\ssl\localweb_temp.req" >nul 2>&1
+certutil -delstore "My" "!SSL_CN!" >nul 2>&1
+certreq -accept -f "!INSTALL_DIR!\ssl\localweb_temp.req" >nul 2>&1
+
+:: Export certificate and key
+certutil -exportPFX -p "localweb" "My" "!SSL_CN!" "!INSTALL_DIR!\ssl\localweb.pfx" >nul 2>&1
+
+:: Convert to PEM format using built-in tools if possible
+echo Creating PEM format certificates...
+(
+echo -----BEGIN CERTIFICATE-----
+certutil -encode "!INSTALL_DIR!\ssl\localweb.pfx" "!INSTALL_DIR!\ssl\temp.b64" >nul 2>&1
+type "!INSTALL_DIR!\ssl\temp.b64" | findstr /v "BEGIN CERTIFICATE" | findstr /v "END CERTIFICATE"
+echo -----END CERTIFICATE-----
+) > "!INSTALL_DIR!\ssl\localweb.crt"
+
+:: For the key, we'll create a placeholder that the server can use
+echo Note: PFX certificate created. The server will use the PFX file directly. > "!INSTALL_DIR!\ssl\localweb.key"
+
+:: Cleanup
+del "!INSTALL_DIR!\ssl\cert_config.inf" >nul 2>&1
+del "!INSTALL_DIR!\ssl\localweb_temp.req" >nul 2>&1
+del "!INSTALL_DIR!\ssl\temp.b64" >nul 2>&1
+
+if exist "!INSTALL_DIR!\ssl\localweb.pfx" (
+    echo ✓ SSL certificates generated successfully!
+    echo.
+    echo Certificate details:
+    echo - Location: !INSTALL_DIR!\ssl\
+    echo - Certificate: localweb.pfx
+    echo - Valid for: !SSL_DAYS! days
+    echo - Common Name: !SSL_CN!
+) else (
+    echo ERROR: Failed to generate SSL certificates.
+    echo Continuing without SSL...
+)
+goto ssl_done
+
+:ssl_python
+:: Check if Python is installed
+python --version >nul 2>&1
+if %errorLevel% neq 0 (
+    py --version >nul 2>&1
+    if %errorLevel% neq 0 (
+        echo Python is not installed.
+        echo Please install Python or use another method.
+        echo.
+        pause
+        goto ssl_certutil
+    )
+    set PYTHON_CMD=py
+) else (
+    set PYTHON_CMD=python
+)
+
+echo.
+echo Configuring SSL certificate details...
+echo.
+echo Enter certificate details (press Enter for defaults):
+echo.
+set /p SSL_CN="Common Name (hostname) [localhost]: "
+if "!SSL_CN!"=="" set SSL_CN=localhost
+
+set /p SSL_DAYS="Certificate validity (days) [365]: "
+if "!SSL_DAYS!"=="" set SSL_DAYS=365
+
+echo.
+echo Generating self-signed SSL certificates using Python...
+
+:: Create Python script for certificate generation
+(
+echo import os
+echo import sys
+echo import datetime
+echo try:
+echo     from cryptography import x509
+echo     from cryptography.x509.oid import NameOID
+echo     from cryptography.hazmat.primitives import hashes
+echo     from cryptography.hazmat.primitives.asymmetric import rsa
+echo     from cryptography.hazmat.primitives import serialization
+echo except ImportError:
+echo     print("Installing required Python module..."^)
+echo     os.system(f"{sys.executable} -m pip install cryptography"^)
+echo     print("Please run the installer again."^)
+echo     sys.exit(1^)
+echo.
+echo def generate_self_signed_cert(hostname, days^):
+echo     # Generate private key
+echo     key = rsa.generate_private_key(
+echo         public_exponent=65537,
+echo         key_size=2048,
+echo     ^)
+echo     
+echo     # Generate certificate
+echo     subject = issuer = x509.Name([
+echo         x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"^),
+echo         x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"State"^),
+echo         x509.NameAttribute(NameOID.LOCALITY_NAME, u"City"^),
+echo         x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"LocalWeb"^),
+echo         x509.NameAttribute(NameOID.COMMON_NAME, hostname^),
+echo     ]^)
+echo     
+echo     cert = x509.CertificateBuilder(^).subject_name(
+echo         subject
+echo     ^).issuer_name(
+echo         issuer
+echo     ^).public_key(
+echo         key.public_key(^)
+echo     ^).serial_number(
+echo         x509.random_serial_number(^)
+echo     ^).not_valid_before(
+echo         datetime.datetime.utcnow(^)
+echo     ^).not_valid_after(
+echo         datetime.datetime.utcnow(^) + datetime.timedelta(days=days^)
+echo     ^).add_extension(
+echo         x509.SubjectAlternativeName([
+echo             x509.DNSName(hostname^),
+echo             x509.DNSName("localhost"^),
+echo             x509.IPAddress("127.0.0.1".encode(^).decode('ascii'^)^),
+echo         ]^),
+echo         critical=False,
+echo     ^).sign(key, hashes.SHA256(^)^)
+echo     
+echo     # Write private key
+echo     with open("localweb.key", "wb"^) as f:
+echo         f.write(key.private_bytes(
+echo             encoding=serialization.Encoding.PEM,
+echo             format=serialization.PrivateFormat.TraditionalOpenSSL,
+echo             encryption_algorithm=serialization.NoEncryption(^)
+echo         ^)^)
+echo     
+echo     # Write certificate
+echo     with open("localweb.crt", "wb"^) as f:
+echo         f.write(cert.public_bytes(serialization.Encoding.PEM^)^)
+echo     
+echo     print("SSL certificate generated successfully!"^)
+echo.
+echo if __name__ == "__main__":
+echo     hostname = sys.argv[1] if len(sys.argv^) ^> 1 else "localhost"
+echo     days = int(sys.argv[2]^) if len(sys.argv^) ^> 2 else 365
+echo     generate_self_signed_cert(hostname, days^)
+) > "!INSTALL_DIR!\ssl\generate_cert.py"
+
+:: Run Python script
+cd "!INSTALL_DIR!\ssl"
+!PYTHON_CMD! generate_cert.py "!SSL_CN!" "!SSL_DAYS!"
+
+if exist "localweb.key" if exist "localweb.crt" (
+    del generate_cert.py >nul 2>&1
+    echo ✓ SSL certificates generated successfully!
+    echo.
+    echo Certificate details:
+    echo - Location: !INSTALL_DIR!\ssl\
+    echo - Certificate: localweb.crt
+    echo - Private Key: localweb.key
+    echo - Valid for: !SSL_DAYS! days
+    echo - Common Name: !SSL_CN!
+) else (
+    del generate_cert.py >nul 2>&1
+    echo ERROR: Failed to generate SSL certificates.
+    echo Continuing without SSL...
+)
+cd "!INSTALL_DIR!"
+goto ssl_done
+
+:skip_ssl
+echo Skipping SSL setup. HTTPS will not be available.
+
+:ssl_done
+
+:: Step 7: Firewall rules
+cls
+echo.
+echo ===============================================
+echo  Step 7: Firewall Configuration
 echo ===============================================
 echo.
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add an interactive self-signed SSL certificate setup wizard to `install.sh` and `install-windows.bat`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This wizard allows users to generate self-signed SSL certificates during installation using either OpenSSL (Unix/macOS) or Windows Certutil, or an optional Python method. It provides user-friendly prompts for certificate details and ensures no PowerShell dependency for Windows installations.