### PR TITLE
Troubleshoot Windows 11 SSL prompt issue

### DIFF
--- a/install-windows.bat
+++ b/install-windows.bat
@@ -297,6 +297,7 @@ echo.
 echo svc.on('install', function(^){
 echo   svc.start(^);
 echo   console.log('Service installed and started!'^);
+echo   process.exit(0^);
 echo }^);
 echo.
 echo svc.install(^);


### PR DESCRIPTION
Add `process.exit(0)` to the generated `install-service.js` to allow the installer to continue to the SSL setup.