### PR TITLE
Update documentation for Unix-only compatibility

### DIFF
--- a/INSTALLERS.md
+++ b/INSTALLERS.md
@@ -1,5 +1,9 @@
 # LocalWeb Server Installers Guide
 
+> ⚠️ **Supported Platforms**
+>
+> Officially supported platforms are **Unix-like operating systems only** (Linux, macOS, FreeBSD, OpenBSD, and related). There is **no official Windows support**. If you're on Windows you'll need to adapt the installers yourself or use a compatibility layer such as WSL.
+
 This guide provides detailed information about the automated installation scripts for LocalWeb Server.
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Local Web
 Serves directory over HTTP & HTTPS
 
+> ⚠️ **Supported Platforms**
+>
+> This project officially supports **Unix-like operating systems only** (Linux, macOS, FreeBSD, OpenBSD, and other POSIX-compliant systems).
+> There is **no official Windows support**. Windows users must adapt these instructions to their environment or use a compatibility layer such as WSL. Contributions to improve Windows compatibility are welcome but not currently maintained by the core team.
+
 Serves directory over HTTP & HTTPS on Ubuntu Server LTS
 
 ## Installation

--- a/SSL-SETUP-README.md
+++ b/SSL-SETUP-README.md
@@ -1,5 +1,9 @@
 # LocalWeb Server - Full-Fledged SSL Certificate Setup
 
+> ⚠️ **Supported Platforms**
+>
+> Officially supported platforms are **Unix-like operating systems only** (Linux, macOS, FreeBSD, OpenBSD, and related). There is **no official Windows support**. Windows users must adapt these instructions themselves or use WSL.
+
 ## Overview
 
 LocalWeb Server now includes a comprehensive SSL certificate generation system that provides production-ready HTTPS support with proper security configurations. This system has been completely redesigned to offer enterprise-grade features while maintaining ease of use.
@@ -11,7 +15,7 @@ LocalWeb Server now includes a comprehensive SSL certificate generation system t
 - **Subject Alternative Names (SANs)** for multiple hostnames and IP addresses
 - **Auto-detection** of local network configuration
 - **Multiple certificate formats**: PEM, PKCS#12 (P12/PFX), PEM bundles
-- **Cross-platform compatibility** for Windows, Linux, and macOS
+- **Cross-platform compatibility** for Unix-like systems (Linux and macOS). Windows is not officially supported.
 
 ### 🌐 **Network-Aware Configuration**
 - **Automatic IP detection** for local network interfaces

--- a/UPLOAD_FEATURE_README.md
+++ b/UPLOAD_FEATURE_README.md
@@ -1,5 +1,9 @@
 # File Upload and Tree Visualization Feature
 
+> ⚠️ **Supported Platforms**
+>
+> Officially supported platforms are **Unix-like operating systems only** (Linux, macOS, FreeBSD, OpenBSD, and related). There is **no official Windows support**. Windows users must adapt these instructions themselves or use WSL.
+
 ## Overview
 
 The application has been enhanced with the following features:


### PR DESCRIPTION
Update documentation to specify official support for Unix-like systems and explicitly state no official Windows support.